### PR TITLE
Removed imports from asyncio.windows events and types

### DIFF
--- a/practice-app/practiceapp/learningPlatform/guards.py
+++ b/practice-app/practiceapp/learningPlatform/guards.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/authentication.py
+++ b/practice-app/practiceapp/learningPlatform/views/authentication.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/sign_up.py
+++ b/practice-app/practiceapp/learningPlatform/views/sign_up.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/student.py
+++ b/practice-app/practiceapp/learningPlatform/views/student.py
@@ -1,5 +1,3 @@
-from asyncio.windows_events import NULL
-from types import NoneType
 from unittest import result
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect

--- a/practice-app/practiceapp/learningPlatform/views/student_enroll.py
+++ b/practice-app/practiceapp/learningPlatform/views/student_enroll.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/student_give_rate.py
+++ b/practice-app/practiceapp/learningPlatform/views/student_give_rate.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/student_my_courses.py
+++ b/practice-app/practiceapp/learningPlatform/views/student_my_courses.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/student_search_course.py
+++ b/practice-app/practiceapp/learningPlatform/views/student_search_course.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/teacher.py
+++ b/practice-app/practiceapp/learningPlatform/views/teacher.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/teacher_add_course.py
+++ b/practice-app/practiceapp/learningPlatform/views/teacher_add_course.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/teacher_course_statistics.py
+++ b/practice-app/practiceapp/learningPlatform/views/teacher_course_statistics.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/teacher_delete_course.py
+++ b/practice-app/practiceapp/learningPlatform/views/teacher_delete_course.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods

--- a/practice-app/practiceapp/learningPlatform/views/teacher_my_courses.py
+++ b/practice-app/practiceapp/learningPlatform/views/teacher_my_courses.py
@@ -1,4 +1,3 @@
-from asyncio.windows_events import NULL
 from django.shortcuts import render
 from django.http import HttpResponse,HttpResponseRedirect
 from django.views.decorators.http import require_http_methods


### PR DESCRIPTION
asyncio.windows_events is not available on OS X and other non-windows operating systems and importing NoneType from types is not required anymore in python. asyncio.windows_events is not used in the code. So removing it has no effect on the behavior.