### PR TITLE
Adding External API Authentication Key to .env

### DIFF
--- a/practice-app/README.md
+++ b/practice-app/README.md
@@ -19,6 +19,8 @@ MYSQL_USER=<YOUR_USERNAME>
 MYSQL_ROOT_PASSWORD=<YOUR_PASSWORD>
 MYSQL_PASSWORD=<YOUR_PASSWORD>
 MYSQL_HOST="localhost"
+
+API_KEY_give_rate=<API_KEY_give_rate>
 ```
 
 After that, ensure that your database server is up and run these commands to set up the database to Django configurations:


### PR DESCRIPTION
Some of us might use authentication keys for the external api they utilize, therefore we have to put the keys into the .env file. I have updated the README.md file accordingly, everyone can add their api key by naming it with the functionality in which the external api is used.