### PR TITLE
Adding the latest version of docker-configure.yml and Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,4 +7,5 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 RUN pip install mysqlclient
 RUN pip install djangorestframework
 RUN pip install django-rest-knox
+RUN pip install django-cors-headers
 COPY . /code/

--- a/backend/budemi/settings.py
+++ b/backend/budemi/settings.py
@@ -40,6 +40,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'knox',
+    'rest_framework.authtoken',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
@@ -50,7 +52,11 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
 ]
+CORS_ALLOW_ALL_ORIGINS = True
+
 
 ROOT_URLCONF = 'budemi.urls'
 
@@ -87,9 +93,9 @@ REST_FRAMEWORK = {
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'budemi',
-        'USER': 'admin',
-        'PASSWORD': '12345',
+        'NAME': 'django_start',
+        'USER': 'root',
+        'PASSWORD': 'root',
         'HOST': 'db',
         'PORT': '3306',
         'OPTIONS': {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -2,18 +2,13 @@ version: '3'
 
 services: 
   db:
-    platform: linux/x86_64
     image: mysql:5.7
     ports:
       - "3306:3306"
     environment:
-     
-       
-       MYSQL_DATABASE: 'budemi'
-       MYSQL_USER: "admin"
-       MYSQL_PASSWORD: '12345'
-       MYSQL_ALLOW_EMPTY_PASSWORD: "True"
-       
+       MYSQL_DATABASE: 'django_start'
+       MYSQL_PASSWORD: 'root'
+       MYSQL_ROOT_PASSWORD: 'root'  
     volumes:
       - .setup.sql:/docker-entrypoint-initbd.d/setup.sql
 
@@ -26,7 +21,6 @@ services:
       - |
           echo "sleep for 10sec"
           sleep 10 
-          python manage.py makemigrations
           python manage.py migrate
           python manage.py runserver 0.0.0.0:8000
           


### PR DESCRIPTION
I have added the latest Docker configs and settings.py for our deployment. Our backend is deployed for the last two days. The port numbers in this docker-compose.yml is configured for AWS EC2. Need  a review. 