### PR TITLE
Bug fix for user logout. (user_token is set to "")

### DIFF
--- a/android/app/src/main/java/com/example/myapplication/view/HomeActivity.kt
+++ b/android/app/src/main/java/com/example/myapplication/view/HomeActivity.kt
@@ -49,6 +49,7 @@ class HomeActivity : AppCompatActivity() {
         startActivity(intent)
     }
     fun toLanding() {
+        user_token=""
         var intent= Intent(applicationContext, LandingActivity::class.java)
         startActivity(intent)
     }

--- a/deliverables/CMPE451_Customer_Presentation_Milestone_1/Customer_Milestone_1.md
+++ b/deliverables/CMPE451_Customer_Presentation_Milestone_1/Customer_Milestone_1.md
@@ -135,6 +135,8 @@ I have assumed several roles on top of my own to implement and bugfix several pa
 
 **Pull Requests:** 
 * Budemi android main: https://github.com/bounswe/bounswe2022group1/pull/397
+* Bug fix for user logout (user_token is set to "") : https://github.com/bounswe/bounswe2022group1/pull/452
+* Milestone1 individual .md files are added : https://github.com/bounswe/bounswe2022group1/pull/451
 
 </details>
 <details>


### PR DESCRIPTION
`Description:` I found a bug in home page. When user logout, it just redirected to the landing page but still it holds its token. I have made the user_token as empty string when it clicks on the "logout" button. I also updated individual .md file.