### PR TITLE
empty url fields are replaced with non-empty string

### DIFF
--- a/frontend/components/addcontent/ContentAdd.js
+++ b/frontend/components/addcontent/ContentAdd.js
@@ -26,6 +26,7 @@ function ContentAdd({routerQuery}) {
       body: JSON.stringify({
         name: name,
         type: "text",
+        url: "xxx",
         text: text,
         learningSpace: routerQuery.id,
       }),

--- a/frontend/components/edit-resource/ResourceEdit.js
+++ b/frontend/components/edit-resource/ResourceEdit.js
@@ -28,6 +28,7 @@ function ResourceEdit({routerQuery}) {
       body: JSON.stringify({
         id: routerQuery.id,
         name: name,
+        url: "xxx",
         type: "text",
         text: text,
       }),

--- a/frontend/components/resource/subpages/Main.js
+++ b/frontend/components/resource/subpages/Main.js
@@ -95,6 +95,7 @@ export default function Main() {
         `http://3.89.218.253:8000/app/content/`,
         {
           id: id,
+          url: "xxx",
           upVoteCount: resource.upVoteCount + 1,
         },
         {


### PR DESCRIPTION
Empty url fields were causing problems while trying to update the resource. We added a non-empty string as url, even if we don't use it.